### PR TITLE
licq: pass signals and events as shared_ptr's

### DIFF
--- a/aosd/src/iface.cpp
+++ b/aosd/src/iface.cpp
@@ -70,7 +70,7 @@ Iface::~Iface()
   pango_layout_unref_aosd(trd.lay);
 }
 
-void Iface::processSignal(Licq::PluginSignal* sig)
+void Iface::processSignal(const Licq::PluginSignal* sig)
 {
   string msg = "";
   bool control = true;
@@ -173,7 +173,7 @@ void Iface::updateTextRenderData()
         (width > conf->wrapWidth ? conf->wrapWidth : width) * PANGO_SCALE);
 }
 
-bool Iface::filterSignal(Licq::PluginSignal* sig, unsigned long ppid)
+bool Iface::filterSignal(const Licq::PluginSignal* sig, unsigned long ppid)
 {
   switch (sig->subSignal())
   {

--- a/aosd/src/iface.h
+++ b/aosd/src/iface.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of Licq, an instant messaging client for UNIX.
- * Copyright (C) 2007-2010 Licq developers
+ * Copyright (C) 2007-2010, 2013 Licq developers <licq-dev@googlegroups.com>
  *
  * Licq is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ public:
   Iface();
   ~Iface();
 
-  void processSignal(Licq::PluginSignal* sig);
+  void processSignal(const Licq::PluginSignal* sig);
   void updateTextRenderData();
 
 private:
@@ -50,7 +50,7 @@ private:
   Conf* conf;
   std::map<unsigned long, time_t> ppidTimers;
 
-  bool filterSignal(Licq::PluginSignal* sig, unsigned long ppid);
+  bool filterSignal(const Licq::PluginSignal* sig, unsigned long ppid);
 
   void displayLayout(std::string& msg, bool control);
 };

--- a/aosd/src/plugin.cpp
+++ b/aosd/src/plugin.cpp
@@ -67,22 +67,14 @@ int AosdPlugin::run()
     switch (msg)
     {
       case PipeSignal:
-        {
-          Licq::PluginSignal* sig = popSignal();
-          if (sig != NULL)
-          {
-            if (!myBlocked)
-              iface->processSignal(sig);
-            delete sig;
-          }
-        }
+        if (!myBlocked)
+          iface->processSignal(popSignal().get());
+        else
+          popSignal();
         break;
 
       case PipeEvent:
-        {
-          Licq::Event* ev = popEvent();
-          delete ev;
-        }
+        popEvent();
         break;
 
       case PipeShutdown:

--- a/auto-reply/src/autoreply.cpp
+++ b/auto-reply/src/autoreply.cpp
@@ -226,23 +226,19 @@ void CLicqAutoReply::ProcessPipe()
   switch (buf[0])
   {
     case PipeSignal:
-    {
-      Licq::PluginSignal* s = popSignal();
       if (myIsEnabled)
-        ProcessSignal(s);
-      delete s;
+        ProcessSignal(popSignal().get());
+      else
+        popSignal();
       break;
-    }
 
     case PipeEvent:
-    {
       // An event is pending (should never happen)
-      Licq::Event* e = popEvent();
       if (myIsEnabled)
-        ProcessEvent(e);
-      delete e;
+        ProcessEvent(popEvent().get());
+      else
+        popEvent();
       break;
-    }
 
     case PipeShutdown:
     {

--- a/auto-reply/src/autoreply.cpp
+++ b/auto-reply/src/autoreply.cpp
@@ -270,7 +270,7 @@ void CLicqAutoReply::ProcessPipe()
 /*---------------------------------------------------------------------------
  * CLicqAutoReply::ProcessSignal
  *-------------------------------------------------------------------------*/
-void CLicqAutoReply::ProcessSignal(Licq::PluginSignal* s)
+void CLicqAutoReply::ProcessSignal(const Licq::PluginSignal* s)
 {
   switch (s->signal())
   {
@@ -288,7 +288,7 @@ void CLicqAutoReply::ProcessSignal(Licq::PluginSignal* s)
 /*---------------------------------------------------------------------------
  * CLicqAutoReply::ProcessEvent
  *-------------------------------------------------------------------------*/
-void CLicqAutoReply::ProcessEvent(Licq::Event* e)
+void CLicqAutoReply::ProcessEvent(const Licq::Event* e)
 {
   const Licq::UserEvent* user_event;
 

--- a/auto-reply/src/autoreply.h
+++ b/auto-reply/src/autoreply.h
@@ -64,8 +64,8 @@ protected:
        m_bSendThroughServer;
 
   void ProcessPipe();
-  void ProcessSignal(Licq::PluginSignal* s);
-  void ProcessEvent(Licq::Event* e);
+  void ProcessSignal(const Licq::PluginSignal* s);
+  void ProcessEvent(const Licq::Event* e);
 
   /**
    * A new event arrived for a user

--- a/forwarder/src/forwarder.cpp
+++ b/forwarder/src/forwarder.cpp
@@ -296,7 +296,7 @@ void CLicqForwarder::ProcessPipe()
 /*---------------------------------------------------------------------------
  * CLicqForwarder::ProcessSignal
  *-------------------------------------------------------------------------*/
-void CLicqForwarder::ProcessSignal(Licq::PluginSignal* s)
+void CLicqForwarder::ProcessSignal(const Licq::PluginSignal* s)
 {
   switch (s->signal())
   {
@@ -317,7 +317,7 @@ void CLicqForwarder::ProcessSignal(Licq::PluginSignal* s)
 /*---------------------------------------------------------------------------
  * CLicqForwarder::ProcessEvent
  *-------------------------------------------------------------------------*/
-void CLicqForwarder::ProcessEvent(Licq::Event* /* e */)
+void CLicqForwarder::ProcessEvent(const Licq::Event* /* e */)
 {
 /*  switch (e->m_nCommand)
   {

--- a/forwarder/src/forwarder.cpp
+++ b/forwarder/src/forwarder.cpp
@@ -258,44 +258,34 @@ void CLicqForwarder::ProcessPipe()
   switch (buf[0])
   {
     case PipeSignal:
-    {
-      Licq::PluginSignal* s = popSignal();
       if (myIsEnabled)
-        ProcessSignal(s);
-      delete s;
+        ProcessSignal(popSignal().get());
+      else
+        popSignal();
       break;
-    }
 
     case PipeEvent:
-    {
       // An event is pending (should never happen)
-      Licq::Event* e = popEvent();
       if (myIsEnabled)
-        ProcessEvent(e);
-      delete e;
+        ProcessEvent(popEvent().get());
+      else
+        popEvent();
       break;
-    }
 
     case PipeShutdown:
-    {
-    gLog.info("Exiting forwarder");
-    m_bExit = true;
-    break;
-  }
+      gLog.info("Exiting forwarder");
+      m_bExit = true;
+      break;
 
     case PipeDisable:
-    {
-    gLog.info("Disabling forwarder");
+      gLog.info("Disabling forwarder");
       myIsEnabled = false;
       break;
-    }
 
     case PipeEnable:
-    {
-    gLog.info("Enabling forwarder");
+      gLog.info("Enabling forwarder");
       myIsEnabled = true;
       break;
-    }
 
   default:
     gLog.warning("Unknown notification type from daemon: %c", buf[0]);

--- a/forwarder/src/forwarder.h
+++ b/forwarder/src/forwarder.h
@@ -76,8 +76,8 @@ protected:
 
 public:
   void ProcessPipe();
-  void ProcessSignal(Licq::PluginSignal* s);
-  void ProcessEvent(Licq::Event* e);
+  void ProcessSignal(const Licq::PluginSignal* s);
+  void ProcessEvent(const Licq::Event* e);
 
   void ProcessUserEvent(const Licq::UserId& userId, unsigned long nId);
   bool ForwardEvent(const Licq::User* u, const Licq::UserEvent* e);

--- a/icq/src/icq.cpp
+++ b/icq/src/icq.cpp
@@ -212,7 +212,7 @@ bool IcqProtocol::start()
   return true;
 }
 
-void IcqProtocol::processSignal(Licq::ProtocolSignal* s)
+void IcqProtocol::processSignal(const Licq::ProtocolSignal* s)
 {
   if (s->userId().protocolId() != LICQ_PPID)
     return;
@@ -222,7 +222,8 @@ void IcqProtocol::processSignal(Licq::ProtocolSignal* s)
   {
     case Licq::ProtocolSignal::SignalLogon:
     {
-      Licq::ProtoLogonSignal* sig = dynamic_cast<Licq::ProtoLogonSignal*>(s);
+      const Licq::ProtoLogonSignal* sig =
+          dynamic_cast<const Licq::ProtoLogonSignal*>(s);
       logon(s->userId(), sig->status());
       break;
     }
@@ -231,7 +232,8 @@ void IcqProtocol::processSignal(Licq::ProtocolSignal* s)
       break;
     case Licq::ProtocolSignal::SignalChangeStatus:
     {
-      Licq::ProtoChangeStatusSignal* sig = dynamic_cast<Licq::ProtoChangeStatusSignal*>(s);
+      const Licq::ProtoChangeStatusSignal* sig =
+          dynamic_cast<const Licq::ProtoChangeStatusSignal*>(s);
       setStatus(sig->status());
       break;
     }
@@ -249,11 +251,12 @@ void IcqProtocol::processSignal(Licq::ProtocolSignal* s)
       icqChangeGroup(s->userId());
       break;
     case Licq::ProtocolSignal::SignalSendMessage:
-      icqSendMessage(dynamic_cast<Licq::ProtoSendMessageSignal*>(s));
+      icqSendMessage(dynamic_cast<const Licq::ProtoSendMessageSignal*>(s));
       break;
     case Licq::ProtocolSignal::SignalNotifyTyping:
     {
-      Licq::ProtoTypingNotificationSignal* sig = dynamic_cast<Licq::ProtoTypingNotificationSignal*>(s);
+      const Licq::ProtoTypingNotificationSignal* sig =
+          dynamic_cast<const Licq::ProtoTypingNotificationSignal*>(s);
       icqTypingNotification(s->userId(), sig->active());
       break;
     }
@@ -261,7 +264,7 @@ void IcqProtocol::processSignal(Licq::ProtocolSignal* s)
       icqAuthorizeGrant(s);
       break;
     case Licq::ProtocolSignal::SignalRefuseAuth:
-      icqAuthorizeRefuse(dynamic_cast<Licq::ProtoRefuseAuthSignal*>(s));
+      icqAuthorizeRefuse(dynamic_cast<const Licq::ProtoRefuseAuthSignal*>(s));
       break;
     case Licq::ProtocolSignal::SignalRequestInfo:
       icqRequestMetaInfo(s->userId(), s);
@@ -291,14 +294,15 @@ void IcqProtocol::processSignal(Licq::ProtocolSignal* s)
       icqRemoveFromIgnoreList(s->userId());
       break;
     case Licq::ProtocolSignal::SignalSendFile:
-      icqFileTransfer(dynamic_cast<Licq::ProtoSendFileSignal*>(s));
+      icqFileTransfer(dynamic_cast<const Licq::ProtoSendFileSignal*>(s));
       break;
     case Licq::ProtocolSignal::SignalCancelEvent:
       CancelEvent(s->eventId());
       break;
     case Licq::ProtocolSignal::SignalSendReply:
     {
-      Licq::ProtoSendEventReplySignal* sig = dynamic_cast<Licq::ProtoSendEventReplySignal*>(s);
+      const Licq::ProtoSendEventReplySignal* sig =
+          dynamic_cast<const Licq::ProtoSendEventReplySignal*>(s);
       if (sig->accept())
         icqFileTransferAccept(sig);
       else
@@ -313,93 +317,109 @@ void IcqProtocol::processSignal(Licq::ProtocolSignal* s)
       break;
     case Licq::ProtocolSignal::SignalRequestAuth:
     {
-      Licq::ProtoRequestAuthSignal* sig = dynamic_cast<Licq::ProtoRequestAuthSignal*>(s);
+      const Licq::ProtoRequestAuthSignal* sig =
+          dynamic_cast<const Licq::ProtoRequestAuthSignal*>(s);
       icqRequestAuth(s->userId(), sig->message());
       break;
     }
     case Licq::ProtocolSignal::SignalRenameGroup:
-      gIcqProtocol.icqRenameGroup(dynamic_cast<Licq::ProtoRenameGroupSignal*>(s));
+      gIcqProtocol.icqRenameGroup(
+          dynamic_cast<const Licq::ProtoRenameGroupSignal*>(s));
       break;
     case Licq::ProtocolSignal::SignalRemoveGroup:
-      gIcqProtocol.icqRemoveGroup(dynamic_cast<Licq::ProtoRemoveGroupSignal*>(s));
+      gIcqProtocol.icqRemoveGroup(
+          dynamic_cast<const Licq::ProtoRemoveGroupSignal*>(s));
       break;
     case Licq::ProtocolSignal::SignalSendUrl:
-      icqSendUrl(dynamic_cast<Licq::ProtoSendUrlSignal*>(s));
+      icqSendUrl(dynamic_cast<const Licq::ProtoSendUrlSignal*>(s));
       break;
     case Licq::ProtocolSignal::SignalProtocolSpecific:
     {
-      ProtocolSignal* ips = dynamic_cast<ProtocolSignal*>(s);
+      const ProtocolSignal* ips = dynamic_cast<const ProtocolSignal*>(s);
       assert(ips != NULL);
       switch (ips->icqSignal())
       {
         case ProtocolSignal::SignalIcqSendContacts:
-          icqSendContactList(dynamic_cast<ProtoSendContactsSignal*>(ips));
+          icqSendContactList(
+              dynamic_cast<const ProtoSendContactsSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqSendSms:
-          icqSendSms(dynamic_cast<ProtoSendSmsSignal*>(ips));
+          icqSendSms(dynamic_cast<const ProtoSendSmsSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqFetchAutoResponse:
           icqFetchAutoResponse(s);
           break;
         case ProtocolSignal::SignalIcqChatRequest:
-          icqChatRequest(dynamic_cast<ProtoChatRequestSignal*>(ips));
+          icqChatRequest(dynamic_cast<const ProtoChatRequestSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqChatRefuse:
-          icqChatRequestRefuse(dynamic_cast<ProtoChatRefuseSignal*>(ips));
+          icqChatRequestRefuse(
+              dynamic_cast<const ProtoChatRefuseSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqChatAccept:
-          icqChatRequestAccept(dynamic_cast<ProtoChatAcceptSignal*>(ips));
+          icqChatRequestAccept(
+              dynamic_cast<const ProtoChatAcceptSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqRequestPlugin:
         {
-          ProtoRequestPluginSignal* sig = dynamic_cast<ProtoRequestPluginSignal*>(ips);
+          const ProtoRequestPluginSignal* sig =
+              dynamic_cast<const ProtoRequestPluginSignal*>(ips);
           icqRequestPluginInfo(s->userId(), sig->type(), sig->direct(), s);
           break;
         }
         case ProtocolSignal::SignalIcqUpdateWork:
-          icqSetWorkInfo(dynamic_cast<ProtoUpdateWorkSignal*>(ips));
+          icqSetWorkInfo(dynamic_cast<const ProtoUpdateWorkSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqUpdateEmail:
-          icqSetEmailInfo(dynamic_cast<ProtoUpdateEmailSignal*>(ips));
+          icqSetEmailInfo(dynamic_cast<const ProtoUpdateEmailSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqUpdateMore:
-          icqSetMoreInfo(dynamic_cast<ProtoUpdateMoreSignal*>(ips));
+          icqSetMoreInfo(dynamic_cast<const ProtoUpdateMoreSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqUpdateSecurity:
-          icqSetSecurityInfo(dynamic_cast<ProtoUpdateSecuritySignal*>(ips));
+          icqSetSecurityInfo(
+              dynamic_cast<const ProtoUpdateSecuritySignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqUpdateInterests:
-          icqSetInterestsInfo(dynamic_cast<ProtoUpdateInterestsSignal*>(ips));
+          icqSetInterestsInfo(
+              dynamic_cast<const ProtoUpdateInterestsSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqUpdateOrgBack:
-          icqSetOrgBackInfo(dynamic_cast<ProtoUpdateOrgBackSignal*>(ips));
+          icqSetOrgBackInfo(
+              dynamic_cast<const ProtoUpdateOrgBackSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqUpdateAbout:
-          icqSetAbout(dynamic_cast<ProtoUpdateAboutSignal*>(ips));
+          icqSetAbout(dynamic_cast<const ProtoUpdateAboutSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqSearchWhitePages:
-          icqSearchWhitePages(dynamic_cast<ProtoSearchWhitePagesSignal*>(ips));
+          icqSearchWhitePages(
+              dynamic_cast<const ProtoSearchWhitePagesSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqSearchUin:
-          icqSearchByUin(dynamic_cast<ProtoSearchUinSignal*>(ips));
+          icqSearchByUin(dynamic_cast<const ProtoSearchUinSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqNotifyAdded:
           icqAlertUser(s->userId());
           break;
         case ProtocolSignal::SignalIcqUpdateTimestamp:
-          icqUpdateInfoTimestamp(dynamic_cast<ProtoUpdateTimestampSignal*>(ips));
+          icqUpdateInfoTimestamp(
+              dynamic_cast<const ProtoUpdateTimestampSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqSetPhoneFollowMe:
-          icqSetPhoneFollowMeStatus((dynamic_cast<ProtoSetPhoneFollowMeSignal*>(ips))->status());
+          icqSetPhoneFollowMeStatus(
+              dynamic_cast<const ProtoSetPhoneFollowMeSignal*>(ips)->status());
           break;
         case ProtocolSignal::SignalIcqUpdateRandomChat:
-          setRandomChatGroup(dynamic_cast<ProtoUpdateRandomChatSignal*>(ips));
+          setRandomChatGroup(
+              dynamic_cast<const ProtoUpdateRandomChatSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqSearchRandom:
-          randomChatSearch(dynamic_cast<ProtoSearchRandomSignal*>(ips));
+          randomChatSearch(
+              dynamic_cast<const ProtoSearchRandomSignal*>(ips));
           break;
         case ProtocolSignal::SignalIcqUpdateUsers:
-          updateAllUsersInGroup((dynamic_cast<ProtoUpdateUsersSignal*>(ips))->groupId());
+          updateAllUsersInGroup(
+              dynamic_cast<const ProtoUpdateUsersSignal*>(ips)->groupId());
           break;
         default:
           // All of these signals are defined within icq protocol

--- a/icq/src/icq.h
+++ b/icq/src/icq.h
@@ -174,7 +174,7 @@ public:
   { myNewSocketPipe.putChar('X'); }
 
   /// Process a protocol signal from daemon
-  void processSignal(Licq::ProtocolSignal* s);
+  void processSignal(const Licq::ProtocolSignal* s);
 
   bool UseServerSideBuddyIcons() const { return m_bUseBART; }
   void SetUseServerSideBuddyIcons(bool b);

--- a/icq/src/icqprotocolplugin.cpp
+++ b/icq/src/icqprotocolplugin.cpp
@@ -146,7 +146,7 @@ bool IcqProtocolPlugin::isOwnerOnline(const Licq::UserId& userId)
 void IcqProtocolPlugin::pushSignal(Licq::ProtocolSignal* signal)
 {
   ProtocolPluginHelper::pushSignal(
-      boost::shared_ptr<Licq::ProtocolSignal>(signal));
+      boost::shared_ptr<const Licq::ProtocolSignal>(signal));
 }
 
 unsigned long IcqProtocolPlugin::icqSendContactList(const Licq::UserId& userId,

--- a/icq/src/icqprotocolplugin.cpp
+++ b/icq/src/icqprotocolplugin.cpp
@@ -127,12 +127,8 @@ void IcqProtocolPlugin::processPipe()
   switch (c)
   {
     case PipeSignal:
-    {
-      Licq::ProtocolSignal* s = popSignal();
-      gIcqProtocol.processSignal(s);
-      delete s;
+      gIcqProtocol.processSignal(popSignal().get());
       break;
-    }
     case PipeShutdown:
       gIcqProtocol.shutdown();
       break;
@@ -145,6 +141,12 @@ bool IcqProtocolPlugin::isOwnerOnline(const Licq::UserId& userId)
 {
   Licq::OwnerReadGuard owner(userId.ownerId());
   return owner.isLocked() && owner->isOnline();
+}
+
+void IcqProtocolPlugin::pushSignal(Licq::ProtocolSignal* signal)
+{
+  ProtocolPluginHelper::pushSignal(
+      boost::shared_ptr<Licq::ProtocolSignal>(signal));
 }
 
 unsigned long IcqProtocolPlugin::icqSendContactList(const Licq::UserId& userId,

--- a/icq/src/icqprotocolplugin.h
+++ b/icq/src/icqprotocolplugin.h
@@ -110,6 +110,8 @@ public:
 private:
   bool isOwnerOnline(const Licq::UserId& userId);
 
+  void pushSignal(Licq::ProtocolSignal* signal);
+
   ~IcqProtocolPlugin();
 };
 

--- a/jabber/src/plugin.cpp
+++ b/jabber/src/plugin.cpp
@@ -120,56 +120,59 @@ void Plugin::rawFileEvent(int fd, int /*revents*/)
   }
 }
 
-void Plugin::processSignal(Licq::ProtocolSignal* signal)
+void Plugin::processSignal(const Licq::ProtocolSignal* signal)
 {
   assert(signal != NULL);
 
   switch (signal->signal())
   {
     case Licq::ProtocolSignal::SignalLogon:
-      doLogon(dynamic_cast<Licq::ProtoLogonSignal*>(signal));
+      doLogon(dynamic_cast<const Licq::ProtoLogonSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalLogoff:
       doLogoff();
       break;
     case Licq::ProtocolSignal::SignalChangeStatus:
-      doChangeStatus(dynamic_cast<Licq::ProtoChangeStatusSignal*>(signal));
+      doChangeStatus(
+          dynamic_cast<const Licq::ProtoChangeStatusSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalAddUser:
-      doAddUser(dynamic_cast<Licq::ProtoAddUserSignal*>(signal));
+      doAddUser(dynamic_cast<const Licq::ProtoAddUserSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalRemoveUser:
-      doRemoveUser(dynamic_cast<Licq::ProtoRemoveUserSignal*>(signal));
+      doRemoveUser(dynamic_cast<const Licq::ProtoRemoveUserSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalRenameUser:
-      doRenameUser(dynamic_cast<Licq::ProtoRenameUserSignal*>(signal));
+      doRenameUser(dynamic_cast<const Licq::ProtoRenameUserSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalChangeUserGroups:
-      doChangeUserGroups(dynamic_cast<Licq::ProtoChangeUserGroupsSignal*>(signal));
+      doChangeUserGroups(
+          dynamic_cast<const Licq::ProtoChangeUserGroupsSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalSendMessage:
-      doSendMessage(dynamic_cast<Licq::ProtoSendMessageSignal*>(signal));
+      doSendMessage(dynamic_cast<const Licq::ProtoSendMessageSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalNotifyTyping:
-      doNotifyTyping(dynamic_cast<Licq::ProtoTypingNotificationSignal*>(signal));
+      doNotifyTyping(
+          dynamic_cast<const Licq::ProtoTypingNotificationSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalGrantAuth:
-      doGrantAuth(dynamic_cast<Licq::ProtoGrantAuthSignal*>(signal));
+      doGrantAuth(dynamic_cast<const Licq::ProtoGrantAuthSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalRefuseAuth:
-      doRefuseAuth(dynamic_cast<Licq::ProtoRefuseAuthSignal*>(signal));
+      doRefuseAuth(dynamic_cast<const Licq::ProtoRefuseAuthSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalRequestInfo:
-      doGetInfo(dynamic_cast<Licq::ProtoRequestInfo*>(signal));
+      doGetInfo(dynamic_cast<const Licq::ProtoRequestInfo*>(signal));
       break;
     case Licq::ProtocolSignal::SignalUpdateInfo:
-      doUpdateInfo(dynamic_cast<Licq::ProtoUpdateInfoSignal*>(signal));
+      doUpdateInfo(dynamic_cast<const Licq::ProtoUpdateInfoSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalRequestAuth:
-      doRequestAuth(dynamic_cast<Licq::ProtoRequestAuthSignal*>(signal));
+      doRequestAuth(dynamic_cast<const Licq::ProtoRequestAuthSignal*>(signal));
       break;
     case Licq::ProtocolSignal::SignalRenameGroup:
-      doRenameGroup(dynamic_cast<Licq::ProtoRenameGroupSignal*>(signal));
+      doRenameGroup(dynamic_cast<const Licq::ProtoRenameGroupSignal*>(signal));
       break;
     default:
       gLog.error("Unknown signal %u", signal->signal());
@@ -181,7 +184,7 @@ void Plugin::processSignal(Licq::ProtocolSignal* signal)
   }
 }
 
-void Plugin::doLogon(Licq::ProtoLogonSignal* signal)
+void Plugin::doLogon(const Licq::ProtoLogonSignal* signal)
 {
   unsigned status = signal->status();
   if (status == Licq::User::OfflineStatus)
@@ -225,7 +228,7 @@ void Plugin::doLogon(Licq::ProtoLogonSignal* signal)
   }
 }
 
-void Plugin::doChangeStatus(Licq::ProtoChangeStatusSignal* signal)
+void Plugin::doChangeStatus(const Licq::ProtoChangeStatusSignal* signal)
 {
   assert(myClient != NULL);
   myClient->changeStatus(signal->status());
@@ -240,7 +243,7 @@ void Plugin::doLogoff()
   myClient = NULL;
 }
 
-void Plugin::doSendMessage(Licq::ProtoSendMessageSignal* signal)
+void Plugin::doSendMessage(const Licq::ProtoSendMessageSignal* signal)
 {
   assert(myClient != NULL);
 
@@ -270,7 +273,7 @@ void Plugin::doSendMessage(Licq::ProtoSendMessageSignal* signal)
   Licq::gPluginManager.pushPluginEvent(event);
 }
 
-void Plugin::doNotifyTyping(Licq::ProtoTypingNotificationSignal* signal)
+void Plugin::doNotifyTyping(const Licq::ProtoTypingNotificationSignal* signal)
 {
   assert(myClient != NULL);
 
@@ -278,7 +281,7 @@ void Plugin::doNotifyTyping(Licq::ProtoTypingNotificationSignal* signal)
       signal->userId().accountId(), signal->active());
 }
 
-void Plugin::doGetInfo(Licq::ProtoRequestInfo* signal)
+void Plugin::doGetInfo(const Licq::ProtoRequestInfo* signal)
 {
   assert(myClient != NULL);
   myClient->getVCard(signal->userId().accountId());
@@ -286,7 +289,7 @@ void Plugin::doGetInfo(Licq::ProtoRequestInfo* signal)
   Licq::gPluginManager.pushPluginEvent(new Licq::Event(signal));
 }
 
-void Plugin::doUpdateInfo(Licq::ProtoUpdateInfoSignal* signal)
+void Plugin::doUpdateInfo(const Licq::ProtoUpdateInfoSignal* signal)
 {
   assert(myClient != NULL);
   Licq::OwnerReadGuard owner(signal->userId());
@@ -302,7 +305,7 @@ void Plugin::doUpdateInfo(Licq::ProtoUpdateInfoSignal* signal)
   Licq::gPluginManager.pushPluginEvent(new Licq::Event(signal));
 }
 
-void Plugin::doAddUser(Licq::ProtoAddUserSignal* signal)
+void Plugin::doAddUser(const Licq::ProtoAddUserSignal* signal)
 {
   assert(myClient != NULL);
   const Licq::UserId userId = signal->userId();
@@ -311,7 +314,8 @@ void Plugin::doAddUser(Licq::ProtoAddUserSignal* signal)
   myClient->addUser(userId.accountId(), groupNames, true);
 }
 
-void Plugin::doChangeUserGroups(Licq::ProtoChangeUserGroupsSignal* signal)
+void Plugin::doChangeUserGroups(
+    const Licq::ProtoChangeUserGroupsSignal* signal)
 {
   assert(myClient != NULL);
   const Licq::UserId userId = signal->userId();
@@ -335,14 +339,14 @@ void Plugin::getUserGroups(const Licq::UserId& userId, gloox::StringList& retGro
   }
 }
 
-void Plugin::doRemoveUser(Licq::ProtoRemoveUserSignal* signal)
+void Plugin::doRemoveUser(const Licq::ProtoRemoveUserSignal* signal)
 {
   assert(myClient != NULL);
   myClient->removeUser(signal->userId().accountId());
   Licq::gUserManager.removeLocalUser(signal->userId());
 }
 
-void Plugin::doRenameUser(Licq::ProtoRenameUserSignal* signal)
+void Plugin::doRenameUser(const Licq::ProtoRenameUserSignal* signal)
 {
   assert(myClient != NULL);
   string newName;
@@ -356,7 +360,7 @@ void Plugin::doRenameUser(Licq::ProtoRenameUserSignal* signal)
   myClient->renameUser(signal->userId().accountId(), newName);
 }
 
-void Plugin::doGrantAuth(Licq::ProtoGrantAuthSignal* signal)
+void Plugin::doGrantAuth(const Licq::ProtoGrantAuthSignal* signal)
 {
   assert(myClient != NULL);
   myClient->grantAuthorization(signal->userId().accountId());
@@ -364,7 +368,7 @@ void Plugin::doGrantAuth(Licq::ProtoGrantAuthSignal* signal)
   Licq::gPluginManager.pushPluginEvent(new Licq::Event(signal));
 }
 
-void Plugin::doRefuseAuth(Licq::ProtoRefuseAuthSignal* signal)
+void Plugin::doRefuseAuth(const Licq::ProtoRefuseAuthSignal* signal)
 {
   assert(myClient != NULL);
   myClient->refuseAuthorization(signal->userId().accountId());
@@ -372,14 +376,14 @@ void Plugin::doRefuseAuth(Licq::ProtoRefuseAuthSignal* signal)
   Licq::gPluginManager.pushPluginEvent(new Licq::Event(signal));
 }
 
-void Plugin::doRequestAuth(Licq::ProtoRequestAuthSignal* signal)
+void Plugin::doRequestAuth(const Licq::ProtoRequestAuthSignal* signal)
 {
   assert(myClient != NULL);
   myClient->requestAuthorization(
       signal->userId().accountId(), signal->message());
 }
 
-void Plugin::doRenameGroup(Licq::ProtoRenameGroupSignal* s)
+void Plugin::doRenameGroup(const Licq::ProtoRenameGroupSignal* s)
 {
   Licq::UserListGuard userList(s->userId());
   BOOST_FOREACH(Licq::User* licqUser, **userList)

--- a/jabber/src/plugin.cpp
+++ b/jabber/src/plugin.cpp
@@ -107,9 +107,7 @@ void Plugin::rawFileEvent(int fd, int /*revents*/)
   {
     case PipeSignal:
     {
-      Licq::ProtocolSignal* signal = popSignal();
-      processSignal(signal);
-      delete signal;
+      processSignal(popSignal().get());
       break;
     }
     case PipeShutdown:

--- a/jabber/src/plugin.h
+++ b/jabber/src/plugin.h
@@ -74,24 +74,24 @@ public:
   void rawFileEvent(int fd, int revents);
 
 private:
-  void processSignal(Licq::ProtocolSignal* signal);
+  void processSignal(const Licq::ProtocolSignal* signal);
   void getUserGroups(const Licq::UserId& userId, gloox::StringList& retGroupNames);
 
-  void doLogon(Licq::ProtoLogonSignal* signal);
-  void doChangeStatus(Licq::ProtoChangeStatusSignal* signal);
+  void doLogon(const Licq::ProtoLogonSignal* signal);
+  void doChangeStatus(const Licq::ProtoChangeStatusSignal* signal);
   void doLogoff();
-  void doSendMessage(Licq::ProtoSendMessageSignal* signal);
-  void doNotifyTyping(Licq::ProtoTypingNotificationSignal* signal);
-  void doGetInfo(Licq::ProtoRequestInfo* signal);
-  void doUpdateInfo(Licq::ProtoUpdateInfoSignal* signal);
-  void doAddUser(Licq::ProtoAddUserSignal* signal);
-  void doChangeUserGroups(Licq::ProtoChangeUserGroupsSignal* signal);
-  void doRemoveUser(Licq::ProtoRemoveUserSignal* signal);
-  void doRenameUser(Licq::ProtoRenameUserSignal* signal);
-  void doGrantAuth(Licq::ProtoGrantAuthSignal* signal);
-  void doRefuseAuth(Licq::ProtoRefuseAuthSignal* signal);
-  void doRequestAuth(Licq::ProtoRequestAuthSignal* signal);
-  void doRenameGroup(Licq::ProtoRenameGroupSignal* s);
+  void doSendMessage(const Licq::ProtoSendMessageSignal* signal);
+  void doNotifyTyping(const Licq::ProtoTypingNotificationSignal* signal);
+  void doGetInfo(const Licq::ProtoRequestInfo* signal);
+  void doUpdateInfo(const Licq::ProtoUpdateInfoSignal* signal);
+  void doAddUser(const Licq::ProtoAddUserSignal* signal);
+  void doChangeUserGroups(const Licq::ProtoChangeUserGroupsSignal* signal);
+  void doRemoveUser(const Licq::ProtoRemoveUserSignal* signal);
+  void doRenameUser(const Licq::ProtoRenameUserSignal* signal);
+  void doGrantAuth(const Licq::ProtoGrantAuthSignal* signal);
+  void doRefuseAuth(const Licq::ProtoRefuseAuthSignal* signal);
+  void doRequestAuth(const Licq::ProtoRequestAuthSignal* signal);
+  void doRenameGroup(const Licq::ProtoRenameGroupSignal* signal);
 
   Client* myClient;
   Licq::MainLoop myMainLoop;

--- a/licq/include/licq/event.h
+++ b/licq/include/licq/event.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of Licq, an instant messaging client for UNIX.
- * Copyright (C) 2010-2012 Licq developers <licq-dev@googlegroups.com>
+ * Copyright (C) 2010-2013 Licq developers <licq-dev@googlegroups.com>
  *
  * Licq is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -265,7 +265,7 @@ public:
   ~Event();
 
 protected:
-  Event(ProtocolSignal* ps, ResultType result = ResultSuccess, UserEvent* ue = NULL);
+  Event(const ProtocolSignal* ps, ResultType result = ResultSuccess, UserEvent* ue = NULL);
   Event(pthread_t caller, unsigned long id, int _nSocketDesc, Packet* p, ConnectType _eConnect,
       const UserId& userId = UserId(), UserEvent* e = NULL);
   Event(int _nSocketDesc, Packet* p, ConnectType _eConnect, const UserId& userId = UserId(),

--- a/licq/include/licq/plugin/generalpluginhelper.h
+++ b/licq/include/licq/plugin/generalpluginhelper.h
@@ -62,10 +62,10 @@ public:
   bool wantSignal(unsigned long signalType) const;
 
   /// Queues the signal and writes PipeSignal to the pipe
-  void pushSignal(boost::shared_ptr<PluginSignal> signal);
+  void pushSignal(boost::shared_ptr<const PluginSignal> signal);
 
   // Queues the event and writes PipeEvent to the pipe
-  void pushEvent(boost::shared_ptr<Event> event);
+  void pushEvent(boost::shared_ptr<const Event> event);
 
 protected:
   GeneralPluginHelper();
@@ -94,7 +94,7 @@ protected:
    *
    * @return The oldest signal on the queue, or NULL if queue is empty
    */
-  boost::shared_ptr<PluginSignal> popSignal();
+  boost::shared_ptr<const PluginSignal> popSignal();
 
   /**
    * Get an event from the event queue
@@ -104,7 +104,7 @@ protected:
    *
    * @return The oldest event on the queue, or NULL if queue is empty
    */
-  boost::shared_ptr<Event> popEvent();
+  boost::shared_ptr<const Event> popEvent();
 
 private:
   LICQ_DECLARE_PRIVATE();

--- a/licq/include/licq/plugin/generalpluginhelper.h
+++ b/licq/include/licq/plugin/generalpluginhelper.h
@@ -62,10 +62,10 @@ public:
   bool wantSignal(unsigned long signalType) const;
 
   /// Queues the signal and writes PipeSignal to the pipe
-  void pushSignal(PluginSignal* signal);
+  void pushSignal(boost::shared_ptr<PluginSignal> signal);
 
   // Queues the event and writes PipeEvent to the pipe
-  void pushEvent(Event* event);
+  void pushEvent(boost::shared_ptr<Event> event);
 
 protected:
   GeneralPluginHelper();
@@ -90,23 +90,21 @@ protected:
    * Get a signal from the signal queue
    *
    * The plugin must call this function to fetch a signal after getting
-   * notified via its pipe. The signal must be deleted by the plugin after
-   * processing.
+   * notified via its pipe.
    *
    * @return The oldest signal on the queue, or NULL if queue is empty
    */
-  PluginSignal* popSignal();
+  boost::shared_ptr<PluginSignal> popSignal();
 
   /**
    * Get an event from the event queue
    *
    * The plugin must call this function to fetch an event after getting
-   * notified via its pipe. The event must be deleted by the plugin after
-   * processing.
+   * notified via its pipe.
    *
    * @return The oldest event on the queue, or NULL if queue is empty
    */
-  Event* popEvent();
+  boost::shared_ptr<Event> popEvent();
 
 private:
   LICQ_DECLARE_PRIVATE();

--- a/licq/include/licq/plugin/generalplugininterface.h
+++ b/licq/include/licq/plugin/generalplugininterface.h
@@ -25,6 +25,8 @@
 
 #include "plugininterface.h"
 
+#include <boost/shared_ptr.hpp>
+
 namespace Licq
 {
 
@@ -66,20 +68,18 @@ public:
   /**
    * Pushes a signal to the plugin.
    *
-   * The plugin takes ownership of the @a signal and is responsible for
-   * deleting it when done with it. The plugin should also take care not to
-   * block the caller (i.e. only queue the signal for later processing).
+   * The plugin should take care not to block the caller (i.e. only queue the
+   * signal for later processing).
    */
-  virtual void pushSignal(PluginSignal* signal) = 0;
+  virtual void pushSignal(boost::shared_ptr<PluginSignal> signal) = 0;
 
   /**
    * Pushes an event to the plugin.
    *
-   * The plugin takes ownership of the @a event and is responsible for
-   * deleting it when done with it. The plugin should also take care not to
-   * block the caller (i.e. only queue the event for later processing).
+   * The plugin should take care not to block the caller (i.e. only queue the
+   * event for later processing).
    */
-  virtual void pushEvent(Event* event) = 0;
+  virtual void pushEvent(boost::shared_ptr<Event> event) = 0;
 
 protected:
   virtual ~GeneralPluginInterface() { /* Empty */ }

--- a/licq/include/licq/plugin/generalplugininterface.h
+++ b/licq/include/licq/plugin/generalplugininterface.h
@@ -71,7 +71,7 @@ public:
    * The plugin should take care not to block the caller (i.e. only queue the
    * signal for later processing).
    */
-  virtual void pushSignal(boost::shared_ptr<PluginSignal> signal) = 0;
+  virtual void pushSignal(boost::shared_ptr<const PluginSignal> signal) = 0;
 
   /**
    * Pushes an event to the plugin.
@@ -79,7 +79,7 @@ public:
    * The plugin should take care not to block the caller (i.e. only queue the
    * event for later processing).
    */
-  virtual void pushEvent(boost::shared_ptr<Event> event) = 0;
+  virtual void pushEvent(boost::shared_ptr<const Event> event) = 0;
 
 protected:
   virtual ~GeneralPluginInterface() { /* Empty */ }

--- a/licq/include/licq/plugin/protocolpluginhelper.h
+++ b/licq/include/licq/plugin/protocolpluginhelper.h
@@ -47,7 +47,7 @@ public:
   void shutdown();
 
   /// Queues the signal and writes PipeSignal to the pipe
-  void pushSignal(ProtocolSignal* signal);
+  void pushSignal(boost::shared_ptr<ProtocolSignal> signal);
 
   /// Returns NULL to make UserManager create a Licq::User
   User* createUser(const UserId& id, bool temporary);
@@ -72,12 +72,11 @@ protected:
    * Called from protocol plugin
    *
    * The plugin must call this function to fetch a signal after getting
-   * notified via its pipe. The signal must be deleted by the plugin after
-   * processing.
+   * notified via its pipe.
    *
    * @return The oldest signal on the queue, or NULL if queue is empty
    */
-  ProtocolSignal* popSignal();
+  boost::shared_ptr<ProtocolSignal> popSignal();
 
 private:
   LICQ_DECLARE_PRIVATE();

--- a/licq/include/licq/plugin/protocolpluginhelper.h
+++ b/licq/include/licq/plugin/protocolpluginhelper.h
@@ -47,7 +47,7 @@ public:
   void shutdown();
 
   /// Queues the signal and writes PipeSignal to the pipe
-  void pushSignal(boost::shared_ptr<ProtocolSignal> signal);
+  void pushSignal(boost::shared_ptr<const ProtocolSignal> signal);
 
   /// Returns NULL to make UserManager create a Licq::User
   User* createUser(const UserId& id, bool temporary);
@@ -76,7 +76,7 @@ protected:
    *
    * @return The oldest signal on the queue, or NULL if queue is empty
    */
-  boost::shared_ptr<ProtocolSignal> popSignal();
+  boost::shared_ptr<const ProtocolSignal> popSignal();
 
 private:
   LICQ_DECLARE_PRIVATE();

--- a/licq/include/licq/plugin/protocolplugininterface.h
+++ b/licq/include/licq/plugin/protocolplugininterface.h
@@ -60,7 +60,7 @@ public:
    * The plugin should take care not to block the caller (i.e. only queue the
    * signal for later processing).
    */
-  virtual void pushSignal(boost::shared_ptr<ProtocolSignal> signal) = 0;
+  virtual void pushSignal(boost::shared_ptr<const ProtocolSignal> signal) = 0;
 
   /**
    * Create a user object

--- a/licq/include/licq/plugin/protocolplugininterface.h
+++ b/licq/include/licq/plugin/protocolplugininterface.h
@@ -25,6 +25,8 @@
 
 #include "plugininterface.h"
 
+#include <boost/shared_ptr.hpp>
+
 namespace Licq
 {
 
@@ -55,11 +57,10 @@ public:
   /**
    * Pushes a signal to the plugin.
    *
-   * The plugin takes ownership of the @a signal and is responsible for
-   * deleting it when done with it. The plugin should also take care not to
-   * block the caller (i.e. only queue the signal for later processing).
+   * The plugin should take care not to block the caller (i.e. only queue the
+   * signal for later processing).
    */
-  virtual void pushSignal(ProtocolSignal* signal) = 0;
+  virtual void pushSignal(boost::shared_ptr<ProtocolSignal> signal) = 0;
 
   /**
    * Create a user object

--- a/licq/src/event.cpp
+++ b/licq/src/event.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of Licq, an instant messaging client for UNIX.
- * Copyright (C) 1998-2012 Licq developers <licq-dev@googlegroups.com>
+ * Copyright (C) 1998-2013 Licq developers <licq-dev@googlegroups.com>
  *
  * Licq is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ using Licq::ProtocolSignal;
 using Licq::UserId;
 using Licq::UserEvent;
 
-Event::Event(ProtocolSignal* ps, ResultType result, UserEvent* ue)
+Event::Event(const ProtocolSignal* ps, ResultType result, UserEvent* ue)
   : m_eResult(result),
     myUserId(ps->userId()),
     thread_plugin(ps->callerThread()),

--- a/licq/src/plugin/generalplugin.cpp
+++ b/licq/src/plugin/generalplugin.cpp
@@ -88,12 +88,12 @@ bool GeneralPlugin::wantSignal(unsigned long signalType) const
   return myInterface->wantSignal(signalType);
 }
 
-void GeneralPlugin::pushSignal(Licq::PluginSignal* signal)
+void GeneralPlugin::pushSignal(boost::shared_ptr<Licq::PluginSignal> signal)
 {
   myInterface->pushSignal(signal);
 }
 
-void GeneralPlugin::pushEvent(Licq::Event* event)
+void GeneralPlugin::pushEvent(boost::shared_ptr<Licq::Event> event)
 {
   myInterface->pushEvent(event);
 }

--- a/licq/src/plugin/generalplugin.cpp
+++ b/licq/src/plugin/generalplugin.cpp
@@ -88,12 +88,13 @@ bool GeneralPlugin::wantSignal(unsigned long signalType) const
   return myInterface->wantSignal(signalType);
 }
 
-void GeneralPlugin::pushSignal(boost::shared_ptr<Licq::PluginSignal> signal)
+void GeneralPlugin::pushSignal(
+    boost::shared_ptr<const Licq::PluginSignal> signal)
 {
   myInterface->pushSignal(signal);
 }
 
-void GeneralPlugin::pushEvent(boost::shared_ptr<Licq::Event> event)
+void GeneralPlugin::pushEvent(boost::shared_ptr<const Licq::Event> event)
 {
   myInterface->pushEvent(event);
 }

--- a/licq/src/plugin/generalplugin.h
+++ b/licq/src/plugin/generalplugin.h
@@ -54,8 +54,8 @@ public:
   void disable();
 
   bool wantSignal(unsigned long signalType) const;
-  void pushSignal(Licq::PluginSignal* signal);
-  void pushEvent(Licq::Event* event);
+  void pushSignal(boost::shared_ptr<Licq::PluginSignal> signal);
+  void pushEvent(boost::shared_ptr<Licq::Event> event);
 
 protected:
   // From Plugin

--- a/licq/src/plugin/generalplugin.h
+++ b/licq/src/plugin/generalplugin.h
@@ -54,8 +54,8 @@ public:
   void disable();
 
   bool wantSignal(unsigned long signalType) const;
-  void pushSignal(boost::shared_ptr<Licq::PluginSignal> signal);
-  void pushEvent(boost::shared_ptr<Licq::Event> event);
+  void pushSignal(boost::shared_ptr<const Licq::PluginSignal> signal);
+  void pushEvent(boost::shared_ptr<const Licq::Event> event);
 
 protected:
   // From Plugin

--- a/licq/src/plugin/generalpluginhelper.cpp
+++ b/licq/src/plugin/generalpluginhelper.cpp
@@ -40,10 +40,10 @@ public:
   Licq::Pipe myPipe;
   unsigned long mySignalMask;
 
-  std::queue<Licq::PluginSignal*> mySignals;
+  std::queue< boost::shared_ptr<Licq::PluginSignal> > mySignals;
   Licq::Mutex mySignalsMutex;
 
-  std::queue<Licq::Event*> myEvents;
+  std::queue< boost::shared_ptr<Licq::Event> > myEvents;
   Licq::Mutex myEventsMutex;
 };
 
@@ -81,7 +81,7 @@ bool GeneralPluginHelper::wantSignal(unsigned long signalType) const
   return (signalType & d->mySignalMask);
 }
 
-void GeneralPluginHelper::pushSignal(PluginSignal* signal)
+void GeneralPluginHelper::pushSignal(boost::shared_ptr<PluginSignal> signal)
 {
   LICQ_D();
   MutexLocker locker(d->mySignalsMutex);
@@ -89,7 +89,7 @@ void GeneralPluginHelper::pushSignal(PluginSignal* signal)
   d->notify(PipeSignal);
 }
 
-void GeneralPluginHelper::pushEvent(Event* event)
+void GeneralPluginHelper::pushEvent(boost::shared_ptr<Event> event)
 {
   LICQ_D();
   MutexLocker locker(d->myEventsMutex);
@@ -120,28 +120,28 @@ void GeneralPluginHelper::setSignalMask(unsigned long signalMask)
   d->mySignalMask = signalMask;
 }
 
-Licq::PluginSignal* GeneralPluginHelper::popSignal()
+boost::shared_ptr<Licq::PluginSignal> GeneralPluginHelper::popSignal()
 {
   LICQ_D();
   MutexLocker locker(d->mySignalsMutex);
   if (!d->mySignals.empty())
   {
-    PluginSignal* signal = d->mySignals.front();
+    boost::shared_ptr<PluginSignal> signal = d->mySignals.front();
     d->mySignals.pop();
     return signal;
   }
-  return NULL;
+  return boost::shared_ptr<PluginSignal>();
 }
 
-Licq::Event* GeneralPluginHelper::popEvent()
+boost::shared_ptr<Licq::Event> GeneralPluginHelper::popEvent()
 {
   LICQ_D();
   MutexLocker locker(d->myEventsMutex);
   if (!d->myEvents.empty())
   {
-    Event* event = d->myEvents.front();
+    boost::shared_ptr<Event> event = d->myEvents.front();
     d->myEvents.pop();
     return event;
   }
-  return NULL;
+  return boost::shared_ptr<Event>();
 }

--- a/licq/src/plugin/generalpluginhelper.cpp
+++ b/licq/src/plugin/generalpluginhelper.cpp
@@ -40,10 +40,10 @@ public:
   Licq::Pipe myPipe;
   unsigned long mySignalMask;
 
-  std::queue< boost::shared_ptr<Licq::PluginSignal> > mySignals;
+  std::queue< boost::shared_ptr<const Licq::PluginSignal> > mySignals;
   Licq::Mutex mySignalsMutex;
 
-  std::queue< boost::shared_ptr<Licq::Event> > myEvents;
+  std::queue< boost::shared_ptr<const Licq::Event> > myEvents;
   Licq::Mutex myEventsMutex;
 };
 
@@ -81,7 +81,8 @@ bool GeneralPluginHelper::wantSignal(unsigned long signalType) const
   return (signalType & d->mySignalMask);
 }
 
-void GeneralPluginHelper::pushSignal(boost::shared_ptr<PluginSignal> signal)
+void GeneralPluginHelper::pushSignal(
+    boost::shared_ptr<const PluginSignal> signal)
 {
   LICQ_D();
   MutexLocker locker(d->mySignalsMutex);
@@ -89,7 +90,7 @@ void GeneralPluginHelper::pushSignal(boost::shared_ptr<PluginSignal> signal)
   d->notify(PipeSignal);
 }
 
-void GeneralPluginHelper::pushEvent(boost::shared_ptr<Event> event)
+void GeneralPluginHelper::pushEvent(boost::shared_ptr<const Event> event)
 {
   LICQ_D();
   MutexLocker locker(d->myEventsMutex);
@@ -120,28 +121,28 @@ void GeneralPluginHelper::setSignalMask(unsigned long signalMask)
   d->mySignalMask = signalMask;
 }
 
-boost::shared_ptr<Licq::PluginSignal> GeneralPluginHelper::popSignal()
+boost::shared_ptr<const Licq::PluginSignal> GeneralPluginHelper::popSignal()
 {
   LICQ_D();
   MutexLocker locker(d->mySignalsMutex);
   if (!d->mySignals.empty())
   {
-    boost::shared_ptr<PluginSignal> signal = d->mySignals.front();
+    boost::shared_ptr<const PluginSignal> signal = d->mySignals.front();
     d->mySignals.pop();
     return signal;
   }
-  return boost::shared_ptr<PluginSignal>();
+  return boost::shared_ptr<const PluginSignal>();
 }
 
-boost::shared_ptr<Licq::Event> GeneralPluginHelper::popEvent()
+boost::shared_ptr<const Licq::Event> GeneralPluginHelper::popEvent()
 {
   LICQ_D();
   MutexLocker locker(d->myEventsMutex);
   if (!d->myEvents.empty())
   {
-    boost::shared_ptr<Event> event = d->myEvents.front();
+    boost::shared_ptr<const Event> event = d->myEvents.front();
     d->myEvents.pop();
     return event;
   }
-  return boost::shared_ptr<Event>();
+  return boost::shared_ptr<const Event>();
 }

--- a/licq/src/plugin/pluginmanager.cpp
+++ b/licq/src/plugin/pluginmanager.cpp
@@ -643,18 +643,12 @@ void PluginManager::pushPluginEvent(Licq::Event* rawEvent)
 void PluginManager::pushPluginSignal(Licq::PluginSignal* rawSignal)
 {
   boost::shared_ptr<Licq::PluginSignal> signal(rawSignal);
-  bool needCopy = false;
 
   MutexLocker locker(myGeneralPluginsMutex);
   BOOST_FOREACH(GeneralPlugin::Ptr plugin, myGeneralPlugins)
   {
     if (plugin->wantSignal(signal->signal()))
-    {
-      plugin->pushSignal(needCopy
-                         ? boost::make_shared<Licq::PluginSignal>(signal.get())
-                         : signal);
-      needCopy = true;
-    }
+      plugin->pushSignal(signal);
   }
 }
 

--- a/licq/src/plugin/pluginmanager.cpp
+++ b/licq/src/plugin/pluginmanager.cpp
@@ -625,8 +625,10 @@ void PluginManager::startPlugin(ProtocolPlugin::Ptr plugin)
   plugin->run(NULL, exitPluginCallback);
 }
 
-void PluginManager::pushPluginEvent(Licq::Event* event)
+void PluginManager::pushPluginEvent(Licq::Event* rawEvent)
 {
+  boost::shared_ptr<Licq::Event> event(rawEvent);
+
   MutexLocker locker(myGeneralPluginsMutex);
   BOOST_FOREACH(GeneralPlugin::Ptr plugin, myGeneralPlugins)
   {
@@ -636,25 +638,30 @@ void PluginManager::pushPluginEvent(Licq::Event* event)
       return;
     }
   }
-
-  // If no plugin got the event, then just delete it
-  delete event;
 }
 
-void PluginManager::pushPluginSignal(Licq::PluginSignal* signal)
+void PluginManager::pushPluginSignal(Licq::PluginSignal* rawSignal)
 {
+  boost::shared_ptr<Licq::PluginSignal> signal(rawSignal);
+  bool needCopy = false;
+
   MutexLocker locker(myGeneralPluginsMutex);
   BOOST_FOREACH(GeneralPlugin::Ptr plugin, myGeneralPlugins)
   {
     if (plugin->wantSignal(signal->signal()))
-      plugin->pushSignal(new Licq::PluginSignal(signal));
+    {
+      plugin->pushSignal(needCopy
+                         ? boost::make_shared<Licq::PluginSignal>(signal.get())
+                         : signal);
+      needCopy = true;
+    }
   }
-  delete signal;
 }
 
-void PluginManager::pushProtocolSignal(Licq::ProtocolSignal* signal)
+void PluginManager::pushProtocolSignal(Licq::ProtocolSignal* rawSignal)
 {
-  unsigned long protocolId = signal->userId().protocolId();
+  boost::shared_ptr<Licq::ProtocolSignal> signal(rawSignal);
+  const unsigned long protocolId = signal->userId().protocolId();
 
   MutexLocker locker(myProtocolPluginsMutex);
   BOOST_FOREACH(ProtocolPlugin::Ptr plugin, myProtocolPlugins)
@@ -667,5 +674,4 @@ void PluginManager::pushProtocolSignal(Licq::ProtocolSignal* signal)
   }
 
   Licq::gLog.error(tr("Invalid protocol plugin requested (%ld)"), protocolId);
-  delete signal;
 }

--- a/licq/src/plugin/protocolplugin.cpp
+++ b/licq/src/plugin/protocolplugin.cpp
@@ -64,7 +64,7 @@ unsigned long ProtocolPlugin::capabilities() const
   return myInterface->capabilities();
 }
 
-void ProtocolPlugin::pushSignal(Licq::ProtocolSignal* signal)
+void ProtocolPlugin::pushSignal(boost::shared_ptr<Licq::ProtocolSignal> signal)
 {
   myInterface->pushSignal(signal);
 }

--- a/licq/src/plugin/protocolplugin.cpp
+++ b/licq/src/plugin/protocolplugin.cpp
@@ -64,7 +64,8 @@ unsigned long ProtocolPlugin::capabilities() const
   return myInterface->capabilities();
 }
 
-void ProtocolPlugin::pushSignal(boost::shared_ptr<Licq::ProtocolSignal> signal)
+void ProtocolPlugin::pushSignal(
+    boost::shared_ptr<const Licq::ProtocolSignal> signal)
 {
   myInterface->pushSignal(signal);
 }

--- a/licq/src/plugin/protocolplugin.h
+++ b/licq/src/plugin/protocolplugin.h
@@ -51,7 +51,7 @@ public:
   unsigned long protocolId() const;
   unsigned long capabilities() const;
 
-  void pushSignal(boost::shared_ptr<Licq::ProtocolSignal> signal);
+  void pushSignal(boost::shared_ptr<const Licq::ProtocolSignal> signal);
   Licq::User* createUser(const Licq::UserId& id, bool temporary);
   Licq::Owner* createOwner(const Licq::UserId& id);
 

--- a/licq/src/plugin/protocolplugin.h
+++ b/licq/src/plugin/protocolplugin.h
@@ -51,7 +51,7 @@ public:
   unsigned long protocolId() const;
   unsigned long capabilities() const;
 
-  void pushSignal(Licq::ProtocolSignal* signal);
+  void pushSignal(boost::shared_ptr<Licq::ProtocolSignal> signal);
   Licq::User* createUser(const Licq::UserId& id, bool temporary);
   Licq::Owner* createOwner(const Licq::UserId& id);
 

--- a/licq/src/plugin/protocolpluginhelper.cpp
+++ b/licq/src/plugin/protocolpluginhelper.cpp
@@ -38,7 +38,7 @@ public:
   void notify(char ch) { myPipe.putChar(ch); }
 
   Licq::Pipe myPipe;
-  std::queue<Licq::ProtocolSignal*> mySignals;
+  std::queue< boost::shared_ptr<Licq::ProtocolSignal> > mySignals;
   Licq::Mutex mySignalsMutex;
 };
 
@@ -53,7 +53,7 @@ void ProtocolPluginHelper::shutdown()
   d->notify(PipeShutdown);
 }
 
-void ProtocolPluginHelper::pushSignal(ProtocolSignal* signal)
+void ProtocolPluginHelper::pushSignal(boost::shared_ptr<ProtocolSignal> signal)
 {
   LICQ_D();
   {
@@ -93,15 +93,15 @@ int ProtocolPluginHelper::getReadPipe() const
   return d->myPipe.getReadFd();
 }
 
-Licq::ProtocolSignal* ProtocolPluginHelper::popSignal()
+boost::shared_ptr<Licq::ProtocolSignal> ProtocolPluginHelper::popSignal()
 {
   LICQ_D();
   MutexLocker locker(d->mySignalsMutex);
   if (!d->mySignals.empty())
   {
-    ProtocolSignal* signal = d->mySignals.front();
+    boost::shared_ptr<ProtocolSignal> signal = d->mySignals.front();
     d->mySignals.pop();
     return signal;
   }
-  return NULL;
+  return boost::shared_ptr<ProtocolSignal>();
 }

--- a/licq/src/plugin/protocolpluginhelper.cpp
+++ b/licq/src/plugin/protocolpluginhelper.cpp
@@ -38,7 +38,7 @@ public:
   void notify(char ch) { myPipe.putChar(ch); }
 
   Licq::Pipe myPipe;
-  std::queue< boost::shared_ptr<Licq::ProtocolSignal> > mySignals;
+  std::queue< boost::shared_ptr<const Licq::ProtocolSignal> > mySignals;
   Licq::Mutex mySignalsMutex;
 };
 
@@ -53,13 +53,12 @@ void ProtocolPluginHelper::shutdown()
   d->notify(PipeShutdown);
 }
 
-void ProtocolPluginHelper::pushSignal(boost::shared_ptr<ProtocolSignal> signal)
+void ProtocolPluginHelper::pushSignal(
+    boost::shared_ptr<const ProtocolSignal> signal)
 {
   LICQ_D();
-  {
-    MutexLocker locker(d->mySignalsMutex);
-    d->mySignals.push(signal);
-  }
+  MutexLocker locker(d->mySignalsMutex);
+  d->mySignals.push(signal);
   d->notify(PipeSignal);
 }
 
@@ -93,15 +92,15 @@ int ProtocolPluginHelper::getReadPipe() const
   return d->myPipe.getReadFd();
 }
 
-boost::shared_ptr<Licq::ProtocolSignal> ProtocolPluginHelper::popSignal()
+boost::shared_ptr<const Licq::ProtocolSignal> ProtocolPluginHelper::popSignal()
 {
   LICQ_D();
   MutexLocker locker(d->mySignalsMutex);
   if (!d->mySignals.empty())
   {
-    boost::shared_ptr<ProtocolSignal> signal = d->mySignals.front();
+    boost::shared_ptr<const ProtocolSignal> signal = d->mySignals.front();
     d->mySignals.pop();
     return signal;
   }
-  return boost::shared_ptr<ProtocolSignal>();
+  return boost::shared_ptr<const ProtocolSignal>();
 }

--- a/licq/src/plugin/tests/generalpluginhelpertest.cpp
+++ b/licq/src/plugin/tests/generalpluginhelpertest.cpp
@@ -103,36 +103,42 @@ TEST_F(GeneralPluginHelperFixture, popEmpty)
   EXPECT_TRUE(helper.popEvent() == NULL);
 }
 
+static void NullDeleter(void*) { /* Empty */ }
+
 TEST_F(GeneralPluginHelperFixture, pushPopSignal)
 {
   using Licq::PluginSignal;
+  using boost::shared_ptr;
+
   PluginSignal* signal1 = reinterpret_cast<PluginSignal*>(10);
   PluginSignal* signal2 = reinterpret_cast<PluginSignal*>(11);
 
-  helper.pushSignal(signal1);
-  helper.pushSignal(signal2);
+  helper.pushSignal(shared_ptr<PluginSignal>(signal1, &NullDeleter));
+  helper.pushSignal(shared_ptr<PluginSignal>(signal2, &NullDeleter));
 
   EXPECT_EQ('S', getPipeChar());
-  EXPECT_EQ(signal1, helper.popSignal());
+  EXPECT_EQ(signal1, helper.popSignal().get());
 
   EXPECT_EQ('S', getPipeChar());
-  EXPECT_EQ(signal2, helper.popSignal());
+  EXPECT_EQ(signal2, helper.popSignal().get());
 }
 
 TEST_F(GeneralPluginHelperFixture, pushPopEvent)
 {
   using Licq::Event;
+  using boost::shared_ptr;
+
   Event* event1 = reinterpret_cast<Event*>(10);
   Event* event2 = reinterpret_cast<Event*>(11);
 
-  helper.pushEvent(event1);
-  helper.pushEvent(event2);
+  helper.pushEvent(shared_ptr<Event>(event1, &NullDeleter));
+  helper.pushEvent(shared_ptr<Event>(event2, &NullDeleter));
 
   EXPECT_EQ('E', getPipeChar());
-  EXPECT_EQ(event1, helper.popEvent());
+  EXPECT_EQ(event1, helper.popEvent().get());
 
   EXPECT_EQ('E', getPipeChar());
-  EXPECT_EQ(event2, helper.popEvent());
+  EXPECT_EQ(event2, helper.popEvent().get());
 }
 
 } // namespace LicqTest

--- a/licq/src/plugin/tests/generalplugintest.cpp
+++ b/licq/src/plugin/tests/generalplugintest.cpp
@@ -50,8 +50,9 @@ public:
   MOCK_METHOD0(enable, void());
   MOCK_METHOD0(disable, void());
   MOCK_CONST_METHOD1(wantSignal, bool(unsigned long signalType));
-  MOCK_METHOD1(pushSignal, void(boost::shared_ptr<Licq::PluginSignal> signal));
-  MOCK_METHOD1(pushEvent, void(boost::shared_ptr<Licq::Event> event));
+  MOCK_METHOD1(pushSignal,
+               void(boost::shared_ptr<const Licq::PluginSignal> signal));
+  MOCK_METHOD1(pushEvent, void(boost::shared_ptr<const Licq::Event> event));
 };
 
 static void NullDeleter(void*) { /* Empty */ }
@@ -84,9 +85,9 @@ TEST_F(GeneralPluginFixture, callApiFunctions)
   using boost::shared_ptr;
 
   unsigned long signalType = 123;
-  shared_ptr<Licq::PluginSignal> signal(
+  shared_ptr<const Licq::PluginSignal> signal(
       reinterpret_cast<Licq::PluginSignal*>(456), &NullDeleter);
-  shared_ptr<Licq::Event> event(
+  shared_ptr<const Licq::Event> event(
       reinterpret_cast<Licq::Event*>(789), &NullDeleter);
 
   InSequence dummy;

--- a/licq/src/plugin/tests/generalplugintest.cpp
+++ b/licq/src/plugin/tests/generalplugintest.cpp
@@ -50,8 +50,8 @@ public:
   MOCK_METHOD0(enable, void());
   MOCK_METHOD0(disable, void());
   MOCK_CONST_METHOD1(wantSignal, bool(unsigned long signalType));
-  MOCK_METHOD1(pushSignal, void(Licq::PluginSignal* signal));
-  MOCK_METHOD1(pushEvent, void(Licq::Event* event));
+  MOCK_METHOD1(pushSignal, void(boost::shared_ptr<Licq::PluginSignal> signal));
+  MOCK_METHOD1(pushEvent, void(boost::shared_ptr<Licq::Event> event));
 };
 
 static void NullDeleter(void*) { /* Empty */ }
@@ -81,9 +81,13 @@ struct GeneralPluginFixture : public ::testing::Test
 
 TEST_F(GeneralPluginFixture, callApiFunctions)
 {
+  using boost::shared_ptr;
+
   unsigned long signalType = 123;
-  Licq::PluginSignal* signal = reinterpret_cast<Licq::PluginSignal*>(456);
-  Licq::Event* event = reinterpret_cast<Licq::Event*>(789);
+  shared_ptr<Licq::PluginSignal> signal(
+      reinterpret_cast<Licq::PluginSignal*>(456), &NullDeleter);
+  shared_ptr<Licq::Event> event(
+      reinterpret_cast<Licq::Event*>(789), &NullDeleter);
 
   InSequence dummy;
   EXPECT_CALL(myMockInterface, description());

--- a/licq/src/plugin/tests/protocolpluginhelpertest.cpp
+++ b/licq/src/plugin/tests/protocolpluginhelpertest.cpp
@@ -75,20 +75,24 @@ TEST_F(ProtocolPluginHelperFixture, popEmpty)
   EXPECT_TRUE(helper.popSignal() == NULL);
 }
 
+static void NullDeleter(void*) { /* Empty */ }
+
 TEST_F(ProtocolPluginHelperFixture, pushPopSignal)
 {
   using Licq::ProtocolSignal;
+  using boost::shared_ptr;
+
   ProtocolSignal* signal1 = reinterpret_cast<ProtocolSignal*>(10);
   ProtocolSignal* signal2 = reinterpret_cast<ProtocolSignal*>(11);
 
-  helper.pushSignal(signal1);
-  helper.pushSignal(signal2);
+  helper.pushSignal(shared_ptr<ProtocolSignal>(signal1, &NullDeleter));
+  helper.pushSignal(shared_ptr<ProtocolSignal>(signal2, &NullDeleter));
 
   EXPECT_EQ('S', getPipeChar());
-  EXPECT_EQ(signal1, helper.popSignal());
+  EXPECT_EQ(signal1, helper.popSignal().get());
 
   EXPECT_EQ('S', getPipeChar());
-  EXPECT_EQ(signal2, helper.popSignal());
+  EXPECT_EQ(signal2, helper.popSignal().get());
 }
 
 TEST_F(ProtocolPluginHelperFixture, createUserOwner)

--- a/licq/src/plugin/tests/protocolplugintest.cpp
+++ b/licq/src/plugin/tests/protocolplugintest.cpp
@@ -46,7 +46,7 @@ public:
 
   MOCK_CONST_METHOD0(protocolId, unsigned long());
   MOCK_CONST_METHOD0(capabilities, unsigned long());
-  MOCK_METHOD1(pushSignal, void(Licq::ProtocolSignal* signal));
+  MOCK_METHOD1(pushSignal, void(boost::shared_ptr<Licq::ProtocolSignal> signal));
   MOCK_METHOD2(createUser, Licq::User*(const Licq::UserId& id, bool temporary));
   MOCK_METHOD1(createOwner, Licq::Owner*(const Licq::UserId& id));
 };
@@ -78,7 +78,8 @@ struct ProtocolPluginFixture : public ::testing::Test
 
 TEST_F(ProtocolPluginFixture, callApiFunctions)
 {
-  Licq::ProtocolSignal* signal = reinterpret_cast<Licq::ProtocolSignal*>(123);
+  boost::shared_ptr<Licq::ProtocolSignal> signal(
+      reinterpret_cast<Licq::ProtocolSignal*>(123), &NullDeleter);
   Licq::UserId user;
   Licq::UserId owner;
 

--- a/licq/src/plugin/tests/protocolplugintest.cpp
+++ b/licq/src/plugin/tests/protocolplugintest.cpp
@@ -46,7 +46,8 @@ public:
 
   MOCK_CONST_METHOD0(protocolId, unsigned long());
   MOCK_CONST_METHOD0(capabilities, unsigned long());
-  MOCK_METHOD1(pushSignal, void(boost::shared_ptr<Licq::ProtocolSignal> signal));
+  MOCK_METHOD1(pushSignal,
+               void(boost::shared_ptr<const Licq::ProtocolSignal> signal));
   MOCK_METHOD2(createUser, Licq::User*(const Licq::UserId& id, bool temporary));
   MOCK_METHOD1(createOwner, Licq::Owner*(const Licq::UserId& id));
 };
@@ -78,7 +79,7 @@ struct ProtocolPluginFixture : public ::testing::Test
 
 TEST_F(ProtocolPluginFixture, callApiFunctions)
 {
-  boost::shared_ptr<Licq::ProtocolSignal> signal(
+  boost::shared_ptr<const Licq::ProtocolSignal> signal(
       reinterpret_cast<Licq::ProtocolSignal*>(123), &NullDeleter);
   Licq::UserId user;
   Licq::UserId owner;

--- a/msn/src/msn.cpp
+++ b/msn/src/msn.cpp
@@ -414,7 +414,7 @@ void CMSN::rawFileEvent(int fd, int /*revents*/)
   }
 }
 
-void CMSN::ProcessSignal(Licq::ProtocolSignal* s)
+void CMSN::ProcessSignal(const Licq::ProtocolSignal* s)
 {
   if (myServerSocket == NULL && s->signal() != Licq::ProtocolSignal::SignalLogon)
     return;
@@ -425,14 +425,16 @@ void CMSN::ProcessSignal(Licq::ProtocolSignal* s)
     {
       if (myServerSocket == NULL)
       {
-        Licq::ProtoLogonSignal* sig = dynamic_cast<Licq::ProtoLogonSignal*>(s);
+        const Licq::ProtoLogonSignal* sig =
+            dynamic_cast<const Licq::ProtoLogonSignal*>(s);
         Logon(sig->userId(), sig->status());
       }
       break;
     }
     case Licq::ProtocolSignal::SignalChangeStatus:
     {
-      Licq::ProtoChangeStatusSignal* sig = dynamic_cast<Licq::ProtoChangeStatusSignal*>(s);
+      const Licq::ProtoChangeStatusSignal* sig =
+          dynamic_cast<const Licq::ProtoChangeStatusSignal*>(s);
       MSNChangeStatus(sig->status());
       break;
     }
@@ -443,38 +445,44 @@ void CMSN::ProcessSignal(Licq::ProtocolSignal* s)
     }
     case Licq::ProtocolSignal::SignalAddUser:
     {
-      Licq::ProtoAddUserSignal* sig = dynamic_cast<Licq::ProtoAddUserSignal*>(s);
+      const Licq::ProtoAddUserSignal* sig =
+          dynamic_cast<const Licq::ProtoAddUserSignal*>(s);
       MSNAddUser(sig->userId());
       break;
     }
     case Licq::ProtocolSignal::SignalRemoveUser:
     {
-      Licq::ProtoRemoveUserSignal* sig = dynamic_cast<Licq::ProtoRemoveUserSignal*>(s);
+      const Licq::ProtoRemoveUserSignal* sig =
+          dynamic_cast<const Licq::ProtoRemoveUserSignal*>(s);
       MSNRemoveUser(sig->userId());
       break;
     }
     case Licq::ProtocolSignal::SignalRenameUser:
     {
-      Licq::ProtoRenameUserSignal* sig = dynamic_cast<Licq::ProtoRenameUserSignal*>(s);
+      const Licq::ProtoRenameUserSignal* sig =
+          dynamic_cast<const Licq::ProtoRenameUserSignal*>(s);
       MSNRenameUser(sig->userId());
       break;
     }
     case Licq::ProtocolSignal::SignalNotifyTyping:
     {
-      Licq::ProtoTypingNotificationSignal* sig = dynamic_cast<Licq::ProtoTypingNotificationSignal*>(s);
+      const Licq::ProtoTypingNotificationSignal* sig =
+          dynamic_cast<const Licq::ProtoTypingNotificationSignal*>(s);
       if (sig->active())
         MSNSendTypingNotification(sig->userId(), sig->convoId());
       break;
     }
     case Licq::ProtocolSignal::SignalSendMessage:
     {
-      Licq::ProtoSendMessageSignal* sig = dynamic_cast<Licq::ProtoSendMessageSignal*>(s);
+      const Licq::ProtoSendMessageSignal* sig =
+          dynamic_cast<const Licq::ProtoSendMessageSignal*>(s);
       MSNSendMessage(sig->eventId(), sig->userId(), sig->message(), sig->callerThread(), sig->convoId());
       break;
     }
     case Licq::ProtocolSignal::SignalGrantAuth:
     {
-      Licq::ProtoGrantAuthSignal* sig = dynamic_cast<Licq::ProtoGrantAuthSignal*>(s);
+      const Licq::ProtoGrantAuthSignal* sig =
+          dynamic_cast<const Licq::ProtoGrantAuthSignal*>(s);
       MSNGrantAuth(sig->userId());
       Licq::gPluginManager.pushPluginEvent(new Licq::Event(s));
       break;
@@ -493,13 +501,15 @@ void CMSN::ProcessSignal(Licq::ProtocolSignal* s)
     }
     case Licq::ProtocolSignal::SignalBlockUser:
     {
-      Licq::ProtoBlockUserSignal* sig = dynamic_cast<Licq::ProtoBlockUserSignal*>(s);
+      const Licq::ProtoBlockUserSignal* sig =
+          dynamic_cast<const Licq::ProtoBlockUserSignal*>(s);
       MSNBlockUser(sig->userId());
       break;
     }
     case Licq::ProtocolSignal::SignalUnblockUser:
     {
-      Licq::ProtoUnblockUserSignal* sig = dynamic_cast<Licq::ProtoUnblockUserSignal*>(s);
+      const Licq::ProtoUnblockUserSignal* sig =
+          dynamic_cast<const Licq::ProtoUnblockUserSignal*>(s);
       MSNUnblockUser(sig->userId());
       break;
     }

--- a/msn/src/msn.cpp
+++ b/msn/src/msn.cpp
@@ -403,8 +403,7 @@ void CMSN::rawFileEvent(int fd, int /*revents*/)
   {
     case PipeSignal:
     {
-      Licq::ProtocolSignal* s = popSignal();
-      ProcessSignal(s);
+      ProcessSignal(popSignal().get());
       break;
     }
 
@@ -418,10 +417,7 @@ void CMSN::rawFileEvent(int fd, int /*revents*/)
 void CMSN::ProcessSignal(Licq::ProtocolSignal* s)
 {
   if (myServerSocket == NULL && s->signal() != Licq::ProtocolSignal::SignalLogon)
-  {
-    delete s;
     return;
-  }
 
   switch (s->signal())
   {
@@ -517,8 +513,6 @@ void CMSN::ProcessSignal(Licq::ProtocolSignal* s)
       break;
     }
   }
-
-  delete s;
 }
 
 void CMSN::socketEvent(Licq::INetSocket* inetSocket, int /*revents*/)

--- a/msn/src/msn.h
+++ b/msn/src/msn.h
@@ -115,7 +115,7 @@ private:
   void socketEvent(Licq::INetSocket* inetSocket, int revents);
   void timeoutEvent(int id);
 
-  void ProcessSignal(Licq::ProtocolSignal* s);
+  void ProcessSignal(const Licq::ProtocolSignal* s);
   void ProcessPipe();
   void ProcessServerPacket(CMSNBuffer *);
   void ProcessSSLServerPacket(CMSNBuffer &);

--- a/osd/src/licq-osd.cpp
+++ b/osd/src/licq-osd.cpp
@@ -92,8 +92,7 @@ struct Config {
 
 
 // some forward declarations
-void ProcessSignal(Licq::PluginSignal* s);
-void ProcessEvent(Licq::Event* e);
+void ProcessSignal(const Licq::PluginSignal* s);
 #ifdef CP_TRANSLATE
     const char *get_iconv_encoding_name(const char *licq_encoding_name);
 string my_translate(const UserId& userId, const string& msg, const char* userenc);
@@ -388,7 +387,7 @@ void OsdPlugin::destructor()
   delete this;
 }
 
-void ProcessSignal(Licq::PluginSignal* s)
+void ProcessSignal(const Licq::PluginSignal* s)
 {
     string username;
     bool notify=false;

--- a/osd/src/licq-osd.cpp
+++ b/osd/src/licq-osd.cpp
@@ -338,16 +338,10 @@ int OsdPlugin::run()
 	{
       case PipeSignal:
       {
-		// read the actual signal from the daemon
-        Licq::PluginSignal* s = popSignal();
-		if (s)
-		{
-		    ProcessSignal(s);
-		    delete s;
-		    s=0;
-		}
-		break;
-	    }
+        // read the actual signal from the daemon
+        ProcessSignal(popSignal().get());
+        break;
+      }
 
 	    // An event is pending - skip it - shouldnt happen
 	    // events are responses to some requests to the licq daemon
@@ -355,8 +349,7 @@ int OsdPlugin::run()
       case PipeEvent:
       {
         gLog.warning("Event received - should not happen in this plugin");
-        Licq::Event* e = popEvent();
-        delete e;
+        popEvent();
         break;
       }
 	    // shutdown command from daemon

--- a/qt4-gui/src/core/plugin.cpp
+++ b/qt4-gui/src/core/plugin.cpp
@@ -44,8 +44,8 @@
 #include "core/gui-defines.h"
 #include "core/licqgui.h"
 
-Q_DECLARE_METATYPE(boost::shared_ptr<Licq::PluginSignal>);
-Q_DECLARE_METATYPE(boost::shared_ptr<Licq::Event>);
+Q_DECLARE_METATYPE(boost::shared_ptr<const Licq::PluginSignal>);
+Q_DECLARE_METATYPE(boost::shared_ptr<const Licq::Event>);
 
 using namespace LicqQtGui;
 /* TRANSLATOR LicqQtGui::QtGuiPlugin */
@@ -59,8 +59,8 @@ QtGuiPlugin::QtGuiPlugin()
   assert(gQtGuiPlugin == NULL);
   gQtGuiPlugin = this;
 
-  qRegisterMetaType< boost::shared_ptr<Licq::PluginSignal> >();
-  qRegisterMetaType< boost::shared_ptr<Licq::Event> >();
+  qRegisterMetaType< boost::shared_ptr<const Licq::PluginSignal> >();
+  qRegisterMetaType< boost::shared_ptr<const Licq::Event> >();
 }
 
 std::string QtGuiPlugin::name() const
@@ -206,12 +206,13 @@ bool QtGuiPlugin::wantSignal(unsigned long signalType) const
   return (signalType & Licq::PluginSignal::SignalAll) != 0;
 }
 
-void QtGuiPlugin::pushSignal(boost::shared_ptr<Licq::PluginSignal> signal)
+void QtGuiPlugin::pushSignal(
+    boost::shared_ptr<const Licq::PluginSignal> signal)
 {
   emit pluginSignal(signal);
 }
 
-void QtGuiPlugin::pushEvent(boost::shared_ptr<Licq::Event> event)
+void QtGuiPlugin::pushEvent(boost::shared_ptr<const Licq::Event> event)
 {
   emit pluginEvent(event);
 }

--- a/qt4-gui/src/core/plugin.cpp
+++ b/qt4-gui/src/core/plugin.cpp
@@ -24,6 +24,7 @@
 
 #include <cstdio>
 #include <QApplication>
+#include <QMetaType>
 #include <QString>
 
 #ifdef USE_KDE
@@ -43,6 +44,9 @@
 #include "core/gui-defines.h"
 #include "core/licqgui.h"
 
+Q_DECLARE_METATYPE(boost::shared_ptr<Licq::PluginSignal>);
+Q_DECLARE_METATYPE(boost::shared_ptr<Licq::Event>);
+
 using namespace LicqQtGui;
 /* TRANSLATOR LicqQtGui::QtGuiPlugin */
 
@@ -54,6 +58,9 @@ QtGuiPlugin::QtGuiPlugin()
 {
   assert(gQtGuiPlugin == NULL);
   gQtGuiPlugin = this;
+
+  qRegisterMetaType< boost::shared_ptr<Licq::PluginSignal> >();
+  qRegisterMetaType< boost::shared_ptr<Licq::Event> >();
 }
 
 std::string QtGuiPlugin::name() const
@@ -199,12 +206,12 @@ bool QtGuiPlugin::wantSignal(unsigned long signalType) const
   return (signalType & Licq::PluginSignal::SignalAll) != 0;
 }
 
-void QtGuiPlugin::pushSignal(Licq::PluginSignal* signal)
+void QtGuiPlugin::pushSignal(boost::shared_ptr<Licq::PluginSignal> signal)
 {
   emit pluginSignal(signal);
 }
 
-void QtGuiPlugin::pushEvent(Licq::Event* event)
+void QtGuiPlugin::pushEvent(boost::shared_ptr<Licq::Event> event)
 {
   emit pluginEvent(event);
 }

--- a/qt4-gui/src/core/plugin.h
+++ b/qt4-gui/src/core/plugin.h
@@ -53,12 +53,12 @@ public:
   void enable();
   void disable();
   bool wantSignal(unsigned long signalType) const;
-  void pushSignal(Licq::PluginSignal* signal);
-  void pushEvent(Licq::Event* event);
+  void pushSignal(boost::shared_ptr<Licq::PluginSignal> signal);
+  void pushEvent(boost::shared_ptr<Licq::Event> event);
 
 signals:
-  void pluginSignal(Licq::PluginSignal* signal);
-  void pluginEvent(Licq::Event* event);
+  void pluginSignal(boost::shared_ptr<Licq::PluginSignal> signal);
+  void pluginEvent(boost::shared_ptr<Licq::Event> event);
   void pluginShutdown();
 
 private:

--- a/qt4-gui/src/core/plugin.h
+++ b/qt4-gui/src/core/plugin.h
@@ -53,12 +53,12 @@ public:
   void enable();
   void disable();
   bool wantSignal(unsigned long signalType) const;
-  void pushSignal(boost::shared_ptr<Licq::PluginSignal> signal);
-  void pushEvent(boost::shared_ptr<Licq::Event> event);
+  void pushSignal(boost::shared_ptr<const Licq::PluginSignal> signal);
+  void pushEvent(boost::shared_ptr<const Licq::Event> event);
 
 signals:
-  void pluginSignal(boost::shared_ptr<Licq::PluginSignal> signal);
-  void pluginEvent(boost::shared_ptr<Licq::Event> event);
+  void pluginSignal(boost::shared_ptr<const Licq::PluginSignal> signal);
+  void pluginEvent(boost::shared_ptr<const Licq::Event> event);
   void pluginShutdown();
 
 private:

--- a/qt4-gui/src/core/signalmanager.cpp
+++ b/qt4-gui/src/core/signalmanager.cpp
@@ -45,10 +45,11 @@ SignalManager::SignalManager()
   assert(gGuiSignalManager == NULL);
   gGuiSignalManager = this;
 
-  connect(gQtGuiPlugin, SIGNAL(pluginSignal(Licq::PluginSignal*)),
-          this, SLOT(processSignal(Licq::PluginSignal*)));
-  connect(gQtGuiPlugin, SIGNAL(pluginEvent(Licq::Event*)),
-          this, SLOT(processEvent(Licq::Event*)));
+  connect(gQtGuiPlugin,
+          SIGNAL(pluginSignal(boost::shared_ptr<Licq::PluginSignal>)),
+          this, SLOT(processSignal(boost::shared_ptr<Licq::PluginSignal>)));
+  connect(gQtGuiPlugin, SIGNAL(pluginEvent(boost::shared_ptr<Licq::Event>)),
+          this, SLOT(processEvent(boost::shared_ptr<Licq::Event>)));
   connect(gQtGuiPlugin, SIGNAL(pluginShutdown()), this, SLOT(shutdown()));
 }
 
@@ -57,7 +58,7 @@ SignalManager::~SignalManager()
   gGuiSignalManager = NULL;
 }
 
-void SignalManager::processSignal(Licq::PluginSignal* sig)
+void SignalManager::processSignal(boost::shared_ptr<Licq::PluginSignal> sig)
 {
   const Licq::UserId& userId = sig->userId();
   unsigned long ppid = userId.protocolId();
@@ -160,17 +161,14 @@ void SignalManager::processSignal(Licq::PluginSignal* sig)
           sig->signal());
       break;
   }
-
-  delete sig;
 }
 
-void SignalManager::processEvent(Licq::Event* ev)
+void SignalManager::processEvent(boost::shared_ptr<Licq::Event> ev)
 {
   if (ev->command() == Licq::Event::CommandSearch)
-    emit searchResult(ev);
+    emit searchResult(ev.get());
   else
-    emit doneUserFcn(ev);
-  delete ev;
+    emit doneUserFcn(ev.get());
 }
 
 void SignalManager::shutdown()

--- a/qt4-gui/src/core/signalmanager.cpp
+++ b/qt4-gui/src/core/signalmanager.cpp
@@ -45,11 +45,14 @@ SignalManager::SignalManager()
   assert(gGuiSignalManager == NULL);
   gGuiSignalManager = this;
 
-  connect(gQtGuiPlugin,
-          SIGNAL(pluginSignal(boost::shared_ptr<Licq::PluginSignal>)),
-          this, SLOT(processSignal(boost::shared_ptr<Licq::PluginSignal>)));
-  connect(gQtGuiPlugin, SIGNAL(pluginEvent(boost::shared_ptr<Licq::Event>)),
-          this, SLOT(processEvent(boost::shared_ptr<Licq::Event>)));
+  connect(
+      gQtGuiPlugin,
+      SIGNAL(pluginSignal(boost::shared_ptr<const Licq::PluginSignal>)),
+      this, SLOT(processSignal(boost::shared_ptr<const Licq::PluginSignal>)));
+  connect(
+      gQtGuiPlugin,
+      SIGNAL(pluginEvent(boost::shared_ptr<const Licq::Event>)),
+      this, SLOT(processEvent(boost::shared_ptr<const Licq::Event>)));
   connect(gQtGuiPlugin, SIGNAL(pluginShutdown()), this, SLOT(shutdown()));
 }
 
@@ -58,7 +61,8 @@ SignalManager::~SignalManager()
   gGuiSignalManager = NULL;
 }
 
-void SignalManager::processSignal(boost::shared_ptr<Licq::PluginSignal> sig)
+void SignalManager::processSignal(
+    boost::shared_ptr<const Licq::PluginSignal> sig)
 {
   const Licq::UserId& userId = sig->userId();
   unsigned long ppid = userId.protocolId();
@@ -163,7 +167,7 @@ void SignalManager::processSignal(boost::shared_ptr<Licq::PluginSignal> sig)
   }
 }
 
-void SignalManager::processEvent(boost::shared_ptr<Licq::Event> ev)
+void SignalManager::processEvent(boost::shared_ptr<const Licq::Event> ev)
 {
   if (ev->command() == Licq::Event::CommandSearch)
     emit searchResult(ev.get());

--- a/qt4-gui/src/core/signalmanager.h
+++ b/qt4-gui/src/core/signalmanager.h
@@ -20,6 +20,7 @@
 #ifndef SIGNALMANAGER_H
 #define SIGNALMANAGER_H
 
+#include <boost/shared_ptr.hpp>
 #include <QObject>
 
 namespace Licq
@@ -161,8 +162,8 @@ signals:
   void ownerRemoved(const Licq::UserId& userId);
 
 private slots:
-  void processSignal(Licq::PluginSignal* sig);
-  void processEvent(Licq::Event* ev);
+  void processSignal(boost::shared_ptr<Licq::PluginSignal> sig);
+  void processEvent(boost::shared_ptr<Licq::Event> ev);
   void shutdown();
 };
 

--- a/qt4-gui/src/core/signalmanager.h
+++ b/qt4-gui/src/core/signalmanager.h
@@ -162,8 +162,8 @@ signals:
   void ownerRemoved(const Licq::UserId& userId);
 
 private slots:
-  void processSignal(boost::shared_ptr<Licq::PluginSignal> sig);
-  void processEvent(boost::shared_ptr<Licq::Event> ev);
+  void processSignal(boost::shared_ptr<const Licq::PluginSignal> sig);
+  void processEvent(boost::shared_ptr<const Licq::Event> ev);
   void shutdown();
 };
 

--- a/rms/src/rms.cpp
+++ b/rms/src/rms.cpp
@@ -398,23 +398,19 @@ void CLicqRMS::ProcessPipe()
   switch (buf)
   {
     case PipeSignal:
-    {
-      Licq::PluginSignal* s = popSignal();
       if (m_bEnabled)
-        ProcessSignal(s);
-      delete s;
+        ProcessSignal(popSignal().get());
+      else
+        popSignal();
       break;
-    }
 
     case PipeEvent:
-    {
       // An event is pending (should never happen)
-      Licq::Event* e = popEvent();
       if (m_bEnabled)
-        ProcessEvent(e);
-      delete e;
+        ProcessEvent(popEvent().get());
+      else
+        popEvent();
       break;
-    }
 
     case PipeShutdown:
       gLog.info("Exiting");

--- a/rms/src/rms.cpp
+++ b/rms/src/rms.cpp
@@ -471,7 +471,7 @@ void CLicqRMS::ProcessLog()
 /*---------------------------------------------------------------------------
  * CLicqRMS::ProcessSignal
  *-------------------------------------------------------------------------*/
-void CLicqRMS::ProcessSignal(Licq::PluginSignal* s)
+void CLicqRMS::ProcessSignal(const Licq::PluginSignal* s)
 {
   switch (s->signal())
   {
@@ -518,12 +518,13 @@ void CLicqRMS::ProcessSignal(Licq::PluginSignal* s)
 /*---------------------------------------------------------------------------
  * CLicqRMS::ProcessEvent
  *-------------------------------------------------------------------------*/
-void CLicqRMS::ProcessEvent(Licq::Event* e)
+void CLicqRMS::ProcessEvent(const Licq::Event* e)
 {
   ClientList ::iterator iter;
   for (iter = clients.begin(); iter != clients.end(); iter++)
   {
-    if ((*iter)->ProcessEvent(e)) break;
+    if ((*iter)->ProcessEvent(e))
+      break;
   }
 }
 
@@ -627,7 +628,7 @@ void CRMSClient::ParseUser(const string& strData)
 /*---------------------------------------------------------------------------
  * CRMSClient::ProcessEvent
  *-------------------------------------------------------------------------*/
-bool CRMSClient::ProcessEvent(Licq::Event* e)
+bool CRMSClient::ProcessEvent(const Licq::Event* e)
 {
   TagList::iterator iter;
   for (iter = tags.begin(); iter != tags.end(); iter++)

--- a/rms/src/rms.h
+++ b/rms/src/rms.h
@@ -82,8 +82,8 @@ protected:
 
 public:
   void ProcessPipe();
-  void ProcessSignal(Licq::PluginSignal* s);
-  void ProcessEvent(Licq::Event* e);
+  void ProcessSignal(const Licq::PluginSignal* s);
+  void ProcessEvent(const Licq::Event* e);
   void ProcessServer();
   void ProcessLog();
 
@@ -141,7 +141,7 @@ protected:
 
   int StateMachine();
   int ProcessCommand();
-  bool ProcessEvent(Licq::Event* e);
+  bool ProcessEvent(const Licq::Event* e);
   bool AddLineToText();
   void ParseUser(const std::string& data);
   int changeStatus(const Licq::UserId& ownerId, const std::string& strStatus);


### PR DESCRIPTION
Avoids memory leak in case plugin isn't ready to handle signal or it it has
been shutdown
