### PR TITLE
licq: fix for C++11 compatibility

### DIFF
--- a/licq/src/licq.cpp
+++ b/licq/src/licq.cpp
@@ -550,7 +550,7 @@ bool CLicq::Init(int argc, char **argv)
         if (!licqConf.get(szKey, pluginName))
           continue;
 
-        bool loaded = LoadPlugin(pluginName, argc, argv);
+        bool loaded = (bool) LoadPlugin(pluginName, argc, argv);
 
         // Make upgrade from 1.4.x-1.8.x and older easier by automatically switching
         //   from kde4/qt4-gui to kde/qt-gui
@@ -559,12 +559,12 @@ bool CLicq::Init(int argc, char **argv)
           if (pluginName == "kde4-gui")
           {
             gLog.warning(tr("Plugin kde4-gui is no longer available, trying to load kde-gui instead."));
-            loaded = LoadPlugin("kde-gui", argc, argv);
+            loaded = (bool) LoadPlugin("kde-gui", argc, argv);
           }
           if (!loaded)
           {
             gLog.warning(tr("Plugin %s is no longer available, trying to load qt-gui instead."), pluginName.c_str());
-            loaded = LoadPlugin("qt-gui", argc, argv);
+            loaded = (bool) LoadPlugin("qt-gui", argc, argv);
           }
         }
 

--- a/licq/src/logging/tests/pluginlogsinktest.cpp
+++ b/licq/src/logging/tests/pluginlogsinktest.cpp
@@ -76,7 +76,7 @@ TEST(PluginLogSink, logMessage)
   message = NULL;
 
   LogSink::Message::Ptr first = sink.popMessage();
-  ASSERT_TRUE(first);
+  ASSERT_TRUE((bool)first);
   EXPECT_EQ("test", first->text);
 
   EXPECT_FALSE(sink.popMessage());

--- a/licq/src/plugin/tests/pluginthreadtest.cpp
+++ b/licq/src/plugin/tests/pluginthreadtest.cpp
@@ -66,7 +66,7 @@ TEST_F(PluginThreadFixture, isThread)
 
 TEST_F(PluginThreadFixture, loadPlugin)
 {
-  EXPECT_TRUE(thread.loadPlugin(""));
+  EXPECT_TRUE((bool)thread.loadPlugin(""));
 }
 
 TEST_F(PluginThreadFixture, loadMissingPlugin)


### PR DESCRIPTION
In C++11 and later boost::shared_ptr does not convert to bool
implicitly, so requires a cast.
